### PR TITLE
Port to async adb from forensic-adb crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.9",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -182,24 +182,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.9",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.9",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -529,9 +529,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -642,7 +642,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.9",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da4a3c17e109f700685ec577c0f85efd9b19bcf15c913985f14dc1ac01775aa"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -811,7 +811,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.9",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "forensic-adb"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be933fe577cf1bdbdcc16c7cd26bc44f101796b001090525e5afca9e1711bc3"
+checksum = "8201364949223d3232995c828ecaccd5e8e9b2eccd59189bb444462919bec12e"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +246,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "forensic-adb"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be933fe577cf1bdbdcc16c7cd26bc44f101796b001090525e5afca9e1711bc3"
+dependencies = [
+ "log",
+ "once_cell",
+ "regex",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "unix_path",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,22 +455,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "mozdevice"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c1b180a91304d9498e47120ac70498909647fefcccf9adb64ed3d6f4bf06c"
-dependencies = [
- "log",
- "once_cell",
- "regex",
- "tempfile",
- "thiserror",
- "unix_path",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -694,6 +701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spytrap-adb"
 version = "0.1.0"
 dependencies = [
@@ -702,9 +719,9 @@ dependencies = [
  "clap",
  "crossterm",
  "env_logger",
+ "forensic-adb",
  "log",
  "maplit",
- "mozdevice",
  "ratatui",
  "regex",
  "serde",
@@ -804,8 +821,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = { version = "0.26.1", features = ["event-stream"] }
 env_logger = "0.10"
-forensic-adb = "0.6"
+forensic-adb = "0.6.1"
 log = "0.4.14"
 ratatui = "0.20.1"
 regex = "1.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = { version = "0.26.1", features = ["event-stream"] }
 env_logger = "0.10"
+forensic-adb = "0.6"
 log = "0.4.14"
-mozdevice = "0.5.0"
 ratatui = "0.20.1"
 regex = "1.5.4"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/accessibility.rs
+++ b/src/accessibility.rs
@@ -2,11 +2,11 @@ use crate::dumpsys;
 use crate::errors::*;
 use crate::iocs::{Suspicion, SuspicionLevel};
 use crate::parsers::accessibility::Accessibility;
-use mozdevice::Device;
+use forensic_adb::Device;
 
-pub fn dump(device: &Device) -> Result<Accessibility> {
+pub async fn dump(device: &Device) -> Result<Accessibility> {
     info!("Reading accessibility settings");
-    let out = dumpsys::dump_service(device, "accessibility")?;
+    let out = dumpsys::dump_service(device, "accessibility").await?;
     out.parse::<Accessibility>()
         .context("Failed to parse accessibility service output")
 }

--- a/src/dumpsys.rs
+++ b/src/dumpsys.rs
@@ -1,14 +1,15 @@
 use crate::errors::*;
-use mozdevice::Device;
+use forensic_adb::Device;
 use std::collections::HashSet;
 
 const CMD_LIST_SERVICES: &str = "dumpsys -l";
 
-pub fn list_services(device: &Device) -> Result<HashSet<String>> {
+pub async fn list_services(device: &Device) -> Result<HashSet<String>> {
     let cmd = CMD_LIST_SERVICES;
     debug!("Executing {:?}", cmd);
     let output = device
         .execute_host_shell_command(cmd)
+        .await
         .with_context(|| anyhow!("Failed to run: {:?}", cmd))?;
 
     let mut services = HashSet::new();
@@ -26,11 +27,12 @@ pub fn list_services(device: &Device) -> Result<HashSet<String>> {
     Ok(services)
 }
 
-pub fn dump_service(device: &Device, service: &str) -> Result<String> {
+pub async fn dump_service(device: &Device, service: &str) -> Result<String> {
     let cmd = format!("dumpsys {}", service);
     debug!("Executing {:?}", cmd);
     let output = device
         .execute_host_shell_command(&cmd)
+        .await
         .with_context(|| anyhow!("Failed to run: {:?}", cmd))?;
     Ok(output)
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,10 +1,10 @@
 use crate::errors::*;
 use crate::iocs::{Suspicion, SuspicionLevel};
 use crate::parsers::{self, package::PackageInfo, package::Permission};
-use mozdevice::Device;
+use forensic_adb::Device;
 use std::borrow::Cow;
 
-pub fn dump(device: &Device, package: &str) -> Result<PackageInfo> {
+pub async fn dump(device: &Device, package: &str) -> Result<PackageInfo> {
     let cmd = format!(
         "dumpsys package {}",
         shell_escape::escape(Cow::Borrowed(package))
@@ -12,6 +12,7 @@ pub fn dump(device: &Device, package: &str) -> Result<PackageInfo> {
     debug!("Executing {:?}", cmd);
     let output = device
         .execute_host_shell_command(&cmd)
+        .await
         .with_context(|| anyhow!("Failed to run: {:?}", cmd))?;
     parsers::package::parse_output(&output, package)
 }

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use mozdevice::Device;
+use forensic_adb::Device;
 
 const CMD: &str = "pm list packages";
 
@@ -8,9 +8,10 @@ pub struct Apk {
     pub id: String,
 }
 
-pub fn list_packages(device: &Device) -> Result<Vec<Apk>> {
+pub async fn list_packages(device: &Device) -> Result<Vec<Apk>> {
     let output = device
         .execute_host_shell_command(CMD)
+        .await
         .with_context(|| anyhow!("Failed to run: {:?}", CMD))?;
     parse_output(&output)
 }

--- a/src/remote_clock.rs
+++ b/src/remote_clock.rs
@@ -1,12 +1,13 @@
 use crate::errors::*;
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
-use mozdevice::Device;
+use forensic_adb::Device;
 
 const DATE_COMMAND: &str = "date -u '+%Y-%m-%d %T %N'";
 
-pub fn determine(device: &Device) -> Result<(DateTime<Utc>, DateTime<Utc>, Duration)> {
+pub async fn determine(device: &Device) -> Result<(DateTime<Utc>, DateTime<Utc>, Duration)> {
     let output = device
         .execute_host_shell_command(DATE_COMMAND)
+        .await
         .with_context(|| anyhow!("Failed to run date command: {:?}", DATE_COMMAND))?;
     let local_time = Utc::now();
     let remote_time = parse(output.trim()).context("Failed to parse remote time")?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,16 +1,17 @@
 use crate::errors::*;
 use crate::iocs::{Suspicion, SuspicionLevel};
 use crate::parsers::settings::Settings;
-use mozdevice::Device;
+use forensic_adb::Device;
 use std::collections::HashMap;
 
-pub fn dump(device: &Device) -> Result<HashMap<String, Settings>> {
+pub async fn dump(device: &Device) -> Result<HashMap<String, Settings>> {
     let mut out = HashMap::new();
     for namespace in ["system", "secure", "global"] {
         let cmd = format!("settings list {}", namespace);
         debug!("Executing {:?}", cmd);
         let output = device
             .execute_host_shell_command(&cmd)
+            .await
             .with_context(|| anyhow!("Failed to run: {:?}", cmd))?;
 
         let settings = output


### PR DESCRIPTION
I've ported `mozdevice` to tokio and uploaded it as [forensic-adb](https://github.com/kpcyrd/forensic-adb). The modified code also removes root checks that are automatically performed on the remote device by the mozdevice crate.