### PR TITLE
Rename update/sync subcommand to `spytrap-adb download-ioc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,42 +43,51 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -193,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -204,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -224,7 +233,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -244,19 +253,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concolor-override"
+name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
-]
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -352,7 +352,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -650,9 +650,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1194,29 +1194,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1433,7 +1433,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1476,7 +1476,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -14,12 +14,21 @@ Based on [stalkerware-indicators] data provided by [Echap].
 
 ## Usage
 
+There's an interactive UI when running the command with no arguments:
+
 ```sh
-# enable usb debugging on the device and connect the android device to the computer
+./spytrap-adb
+```
+
+Enable usb debugging on the device and connect the android device to the computer.
+
+You can also invoke some commands directly for non-interactive use:
+
+```sh
 # list available devices
 ./spytrap-adb list
 # download ioc.yaml from https://github.com/AssoEchap/stalkerware-indicators
-./spytrap-adb update
+./spytrap-adb download-iocs
 # scan the first connected device
 ./spytrap-adb scan
 ```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ You can also invoke some commands directly for non-interactive use:
 ```sh
 # list available devices
 ./spytrap-adb list
-# download ioc.yaml from https://github.com/AssoEchap/stalkerware-indicators
-./spytrap-adb download-iocs
+# download indicators of compromise from https://github.com/AssoEchap/stalkerware-indicators
+./spytrap-adb download-ioc
 # scan the first connected device
 ./spytrap-adb scan
 ```

--- a/src/accessibility.rs
+++ b/src/accessibility.rs
@@ -1,6 +1,6 @@
 use crate::dumpsys;
 use crate::errors::*;
-use crate::iocs::{Suspicion, SuspicionLevel};
+use crate::ioc::{Suspicion, SuspicionLevel};
 use crate::parsers::accessibility::Accessibility;
 use forensic_adb::Device;
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,7 +30,7 @@ pub enum AdbServerChoice {
 pub enum SubCommand {
     Scan(Scan),
     List(List),
-    Sync(SyncIoc),
+    DownloadIocs(DownloadIocs),
 }
 
 /// Run a scan on a given device
@@ -52,4 +52,4 @@ pub struct List {}
 
 /// Download the latest version of stalkerware-indicators ioc.yaml
 #[derive(Debug, Parser)]
-pub struct SyncIoc {}
+pub struct DownloadIocs {}

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,7 +30,7 @@ pub enum AdbServerChoice {
 pub enum SubCommand {
     Scan(Scan),
     List(List),
-    DownloadIocs(DownloadIocs),
+    DownloadIoc(DownloadIoc),
 }
 
 /// Run a scan on a given device
@@ -52,4 +52,4 @@ pub struct List {}
 
 /// Download the latest version of stalkerware-indicators ioc.yaml
 #[derive(Debug, Parser)]
-pub struct DownloadIocs {}
+pub struct DownloadIoc {}

--- a/src/ioc.rs
+++ b/src/ioc.rs
@@ -132,7 +132,7 @@ impl Repository {
         }
     }
 
-    pub async fn download_iocs_file(&mut self) -> Result<()> {
+    pub async fn download_ioc_file(&mut self) -> Result<()> {
         let commit = self
             .current_github_commit(IOC_GIT_REFS_URL)
             .await

--- a/src/iocs.rs
+++ b/src/iocs.rs
@@ -132,8 +132,7 @@ impl Repository {
         }
     }
 
-    pub async fn sync_ioc_file(&mut self) -> Result<()> {
-        debug!("Starting update check");
+    pub async fn download_iocs_file(&mut self) -> Result<()> {
         let commit = self
             .current_github_commit(IOC_GIT_REFS_URL)
             .await
@@ -174,8 +173,6 @@ impl Repository {
         self.write_state_file()
             .await
             .context("Failed to write update state file")?;
-
-        debug!("Update check complete");
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod accessibility;
 pub mod args;
 pub mod dumpsys;
 pub mod errors;
-pub mod iocs;
+pub mod ioc;
 pub mod package;
 pub mod parsers;
 pub mod pm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,11 @@ async fn run(args: Args) -> Result<()> {
                 );
             }
         }
-        Some(SubCommand::Sync(_sync)) => {
+        Some(SubCommand::DownloadIocs(_sync)) => {
             let mut repo = iocs::Repository::init().await?;
-            repo.sync_ioc_file()
+            repo.download_iocs_file()
                 .await
-                .context("Failed to sync stalkerware-indicators ioc.yaml")?;
+                .context("Failed to download stalkerware-indicators ioc.yaml")?;
         }
         None => {
             let mut app = tui::App::new(adb_host);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use env_logger::Env;
 use forensic_adb::{AndroidStorageInput, Host};
 use spytrap_adb::args::{self, Args, SubCommand};
 use spytrap_adb::errors::*;
-use spytrap_adb::iocs;
+use spytrap_adb::ioc;
 use spytrap_adb::rules;
 use spytrap_adb::scan;
 use spytrap_adb::tui;
@@ -19,7 +19,7 @@ async fn run(args: Args) -> Result<()> {
             let rules_path = if let Some(path) = &scan.rules {
                 Cow::Borrowed(path)
             } else {
-                let path = iocs::Repository::ioc_file_path()?;
+                let path = ioc::Repository::ioc_file_path()?;
                 Cow::Owned(path)
             };
 
@@ -30,7 +30,7 @@ async fn run(args: Args) -> Result<()> {
                 rules.len()
             );
 
-            let repo = iocs::Repository::init().await?;
+            let repo = ioc::Repository::init().await?;
             if let Some(update_state) = &repo.update_state {
                 if update_state.sha256 == sha256 {
                     info!(
@@ -76,9 +76,9 @@ async fn run(args: Args) -> Result<()> {
                 );
             }
         }
-        Some(SubCommand::DownloadIocs(_sync)) => {
-            let mut repo = iocs::Repository::init().await?;
-            repo.download_iocs_file()
+        Some(SubCommand::DownloadIoc(_download)) => {
+            let mut repo = ioc::Repository::init().await?;
+            repo.download_ioc_file()
                 .await
                 .context("Failed to download stalkerware-indicators ioc.yaml")?;
         }

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use crate::iocs::{Suspicion, SuspicionLevel};
+use crate::ioc::{Suspicion, SuspicionLevel};
 use crate::parsers::{self, package::PackageInfo, package::Permission};
 use forensic_adb::Device;
 use std::borrow::Cow;

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -2,7 +2,7 @@ use crate::accessibility;
 use crate::args;
 use crate::dumpsys;
 use crate::errors::*;
-use crate::iocs::{Suspicion, SuspicionLevel};
+use crate::ioc::{Suspicion, SuspicionLevel};
 use crate::package;
 use crate::pm;
 use crate::remote_clock;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use crate::iocs::{Suspicion, SuspicionLevel};
+use crate::ioc::{Suspicion, SuspicionLevel};
 use crate::parsers::settings::Settings;
 use forensic_adb::Device;
 use std::collections::HashMap;


### PR DESCRIPTION
This aligns the subcommand with `mvt-android download-iocs` and `mvt-ios download-iocs`.

Also update dependencies and fix a crash if Enter is pressed while no devices are connected.