### PR TITLE
Minor bugfixes, mark "Play Protect enabled" as good finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",

--- a/src/ioc.rs
+++ b/src/ioc.rs
@@ -29,6 +29,7 @@ impl Suspicion {
                     SuspicionLevel::High => "high",
                     SuspicionLevel::Medium => "medium",
                     SuspicionLevel::Low => "low",
+                    SuspicionLevel::Good => "good",
                 },
                 self.level.terminal_color(),
             ),
@@ -40,6 +41,7 @@ impl Suspicion {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub enum SuspicionLevel {
+    Good,
     Low,
     Medium,
     High,
@@ -53,6 +55,9 @@ impl SuspicionLevel {
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
             SuspicionLevel::Low => Style::default().add_modifier(Modifier::BOLD),
+            SuspicionLevel::Good => Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         }
     }
 }

--- a/src/ioc.rs
+++ b/src/ioc.rs
@@ -38,7 +38,7 @@ impl Suspicion {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub enum SuspicionLevel {
     Low,
     Medium,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,7 +39,14 @@ impl Settings {
                     }
                 }
                 "package_verifier_user_consent" => {
-                    if value != "1" {
+                    if value == "1" {
+                        info!("Scanning apps with Google Play Protect has been enabled");
+                        sus.push(Suspicion {
+                            level: SuspicionLevel::Good,
+                            description: "Scanning apps with Google Play Protect has been enabled"
+                                .to_string(),
+                        });
+                    } else {
                         warn!("Scanning apps with Google Play Protect has been disabled");
                         sus.push(Suspicion {
                             level: SuspicionLevel::High,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,22 +30,21 @@ impl Settings {
             match key.as_str() {
                 "package_verifier_enable" => {
                     if value != "1" {
-                        warn!("Scanning apps with Google Play Protect has been disabled");
+                        warn!("Google Play Protect has been turned off programmatically");
                         sus.push(Suspicion {
                             level: SuspicionLevel::High,
-                            description: "Scanning apps with Google Play Protect has been disabled"
+                            description: "Google Play Protect has been turned off programmatically"
                                 .to_string(),
                         });
                     }
                 }
                 "package_verifier_user_consent" => {
                     if value != "1" {
-                        warn!("Mandatory user consent for app installations has been disabled");
+                        warn!("Scanning apps with Google Play Protect has been disabled");
                         sus.push(Suspicion {
-                            level: SuspicionLevel::Medium,
-                            description:
-                                "Mandatory user consent for app installations has been disabled"
-                                    .to_string(),
+                            level: SuspicionLevel::High,
+                            description: "Scanning apps with Google Play Protect has been disabled"
+                                .to_string(),
                         });
                     }
                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,27 +30,26 @@ impl Settings {
             match key.as_str() {
                 "package_verifier_enable" => {
                     if value != "1" {
-                        warn!("Google Play Protect has been turned off programmatically");
+                        warn!("Google Play Protect is turned off");
                         sus.push(Suspicion {
                             level: SuspicionLevel::High,
-                            description: "Google Play Protect has been turned off programmatically"
-                                .to_string(),
+                            description: "Google Play Protect is turned off".to_string(),
                         });
                     }
                 }
                 "package_verifier_user_consent" => {
                     if value == "1" {
-                        info!("Scanning apps with Google Play Protect has been enabled");
+                        info!("Scanning apps with Google Play Protect is enabled");
                         sus.push(Suspicion {
                             level: SuspicionLevel::Good,
-                            description: "Scanning apps with Google Play Protect has been enabled"
+                            description: "Scanning apps with Google Play Protect is enabled"
                                 .to_string(),
                         });
                     } else {
-                        warn!("Scanning apps with Google Play Protect has been disabled");
+                        warn!("Scanning apps with Google Play Protect is disabled");
                         sus.push(Suspicion {
                             level: SuspicionLevel::High,
-                            description: "Scanning apps with Google Play Protect has been disabled"
+                            description: "Scanning apps with Google Play Protect is disabled"
                                 .to_string(),
                         });
                     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -150,7 +150,7 @@ impl App {
         }
     }
 
-    pub fn save_cursor(&mut self) {
+    pub async fn save_cursor(&mut self) -> Result<()> {
         self.cursor_backtrace.push(SavedCursor {
             offset: self.offset,
             cursor: self.cursor,
@@ -158,6 +158,8 @@ impl App {
         });
         self.offset = 0;
         self.cursor = 0;
+        self.stop_timer().await?;
+        Ok(())
     }
 
     pub fn key_up(&mut self) {
@@ -328,6 +330,8 @@ pub async fn handle_key<B: Backend>(
                 app.cursor = saved.cursor;
                 if let Some(interval) = saved.interval {
                     app.start_timer(interval).await?;
+                } else {
+                    app.stop_timer().await?;
                 }
             }
         }
@@ -391,7 +395,7 @@ pub async fn handle_key<B: Backend>(
                 });
                 app.scan = Some(Scan::default());
                 app.cancel_scan = Some(cancel_tx);
-                app.save_cursor();
+                app.save_cursor().await?;
                 app.start_timer(SCAN_ACTIVITY_TICK_INTERVAL).await?;
             }
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -233,6 +233,7 @@ impl AppInfos {
             SuspicionLevel::High => self.high.push(item),
             SuspicionLevel::Medium => self.medium.push(item),
             SuspicionLevel::Low => self.low.push(item),
+            SuspicionLevel::Good => (),
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -518,6 +518,11 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Resul
                     Message::Suspicion(sus) => {
                         if let Some(scan) = &mut app.scan {
                             scan.findings.push(sus);
+                            scan.findings.sort_by(|a, b| {
+                                a.level.cmp(&b.level)
+                                    .reverse()
+                                    .then(a.description.cmp(&b.description))
+                            });
                         }
                     }
                     Message::App { name, sus } => {


### PR DESCRIPTION
- If Play Protect is enabled we state this explicitly in the report.
- The `package_verifier_user_consent` description has been fixed, the one based on ChatGPT wasn't factually correct.
- When navigating "back" to the previous view and restoring the cursor position, also stop the background timer if the restored view hasn't requested periodic ticks.
- The severity-sorting was previously only implemented for apps (sort apps with more severe findings higher), and is now also implemented for findings that are related to the system instead of an app.