### PR TITLE
Add controls to download ioc database from UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1221,18 +1222,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.176"
+version = "1.0.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
+checksum = "63ba2516aa6bf82e0b19ca8b50019d52df58455d3cf9bdaf6315225fdd0c560a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.176"
+version = "1.0.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
+checksum = "401797fe7833d72109fedec6bfcbe67c0eed9b99772f26eb8afd261f0abc6fd3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +92,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -93,20 +102,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "async-compression"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
 dependencies = [
  "brotli",
  "flate2",
@@ -123,6 +132,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +157,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -208,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -219,31 +249,30 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -281,9 +310,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -303,7 +332,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -361,7 +390,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -388,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -400,7 +429,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -415,12 +444,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "flate2"
@@ -480,6 +506,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,9 +535,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -525,10 +564,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.19"
+name = "gimli"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -563,18 +608,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -624,9 +660,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -648,10 +684,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -713,48 +750,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "indoc"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -767,15 +789,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -829,26 +851,35 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -893,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,9 +937,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -912,31 +949,33 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce841e0486e7c2412c3740168ede33adeba8e154a15107b879d8162d77c7174e"
+checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "cassowary",
  "crossterm",
+ "indoc",
+ "paste",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -947,7 +986,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -956,7 +995,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -972,9 +1011,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -983,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -1044,24 +1095,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.20"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -1083,18 +1139,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -1102,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -1117,18 +1173,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1142,11 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1155,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1165,18 +1221,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1185,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1208,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -1238,9 +1294,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1277,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1346,9 +1402,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1357,16 +1413,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1380,18 +1435,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1415,11 +1470,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1428,7 +1484,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1523,9 +1579,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -1565,9 +1621,9 @@ checksum = "2ace0b4755d0a2959962769239d56267f8a024fef2d9b32666b3dcd0946b0906"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
@@ -1594,9 +1650,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "serde",
@@ -1751,21 +1807,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1775,24 +1816,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1802,21 +1837,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1826,21 +1849,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1850,21 +1861,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dirs = "5.0.0"
 env_logger = "0.10"
 forensic-adb = "0.6.2"
 hex = "0.4.3"
-indexmap = "2"
+indexmap = { version = "2", features = ["serde"] }
 log = "0.4.14"
 ratatui = "0.22"
 regex = "1.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ forensic-adb = "0.6.2"
 hex = "0.4.3"
 indexmap = "2"
 log = "0.4.14"
-ratatui = "0.21"
+ratatui = "0.22"
 regex = "1.5.4"
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls-native-roots", "brotli", "gzip", "deflate", "json"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,8 +42,9 @@ pub enum SubCommand {
 #[derive(Debug, Parser)]
 pub struct Scan {
     pub serial: Option<String>,
+    /// Use specific rule files instead of latest downloaded
     #[arg(long)]
-    pub rules: Option<PathBuf>,
+    pub rules: Vec<PathBuf>,
     #[arg(long)]
     pub test_load_only: bool,
     /// Do not scan apps for suspicious permissions

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,105 @@
+use crate::errors::*;
+use chrono::{offset::Utc, DateTime};
+use serde::{Deserialize, Serialize};
+
+const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    http: reqwest::Client,
+}
+
+impl Client {
+    pub fn new() -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .build()
+            .context("Failed to setup http client")?;
+        Ok(Self { http })
+    }
+
+    pub async fn get(&self, url: &str) -> Result<reqwest::Response> {
+        let req = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .context("Failed to send HTTP request")?;
+
+        let status = req.status();
+        let headers = req.headers();
+        trace!("Received response from server: status={status:?}, headers={headers:?}");
+
+        let req = req.error_for_status()?;
+        Ok(req)
+    }
+
+    pub async fn github_branch_metadata(&self, base_url: &str, branch: &str) -> Result<GithubRef> {
+        let url = format!("{}/{}", base_url, branch);
+
+        info!("Fetching git repository meta data: {url:?}...");
+        let metadata = self
+            .get(&url)
+            .await?
+            .json::<GithubBranch>()
+            .await
+            .context("Failed to receive http response")?;
+
+        let commit = metadata.commit;
+        debug!("Found github commit for branch {branch:?}: {commit:?}");
+        Ok(commit)
+    }
+
+    pub async fn github_download_file(
+        &self,
+        base_url: &str,
+        commit: &GithubRef,
+        filename: &str,
+    ) -> Result<String> {
+        let url = base_url
+            .replace("{{commit}}", &commit.sha)
+            .replace("{{filename}}", filename);
+        info!("Downloading IOC file from {url:?}...");
+        let body = self
+            .get(&url)
+            .await?
+            .text()
+            .await
+            .context("Failed to download HTTP response")?;
+        Ok(body)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GithubBranch {
+    pub name: String,
+    pub commit: GithubRef,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GithubRef {
+    pub sha: String,
+    pub commit: GithubCommit,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GithubCommit {
+    pub committer: GithubGitAuthor,
+}
+
+impl GithubCommit {
+    pub fn release_timestamp(&self) -> Result<i64> {
+        let date = &self.committer.date;
+        let dt = DateTime::parse_from_rfc3339(date)
+            .with_context(|| anyhow!("Failed to parse datetime from github: {date:?}"))?;
+        let dt = DateTime::<Utc>::from(dt);
+        Ok(dt.timestamp())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GithubGitAuthor {
+    pub name: String,
+    pub email: String,
+    pub date: String,
+}

--- a/src/ioc.rs
+++ b/src/ioc.rs
@@ -1,6 +1,8 @@
 use crate::errors::*;
+use crate::http;
+use crate::rules;
 use crate::utils;
-use chrono::{offset::Utc, DateTime};
+use indexmap::IndexMap;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use serde::{Deserialize, Serialize};
@@ -9,12 +11,12 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 
 // query the latest commit to detect if we need to update
-const IOC_GIT_BRANCH_URL: &str =
-    "https://api.github.com/repos/AssoEchap/stalkerware-indicators/branches/master";
+const IOC_GIT_BRANCHES_URL: &str =
+    "https://api.github.com/repos/AssoEchap/stalkerware-indicators/branches";
 const IOC_GIT_BRANCH: &str = "master";
-const IOC_REFRESH_INTERVAL: i64 = 3 * 60; // Assume the cache is ok for 3h
 const IOC_DOWNLOAD_URL: &str =
-    "https://github.com/AssoEchap/stalkerware-indicators/raw/{{commit}}/ioc.yaml";
+    "https://github.com/AssoEchap/stalkerware-indicators/raw/{{commit}}/{{filename}}";
+const IOC_DB_FILES: &[&str] = &["ioc.yaml", "watchware.yaml"];
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Suspicion {
@@ -63,17 +65,19 @@ impl SuspicionLevel {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct UpdateState {
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepositoryContent {
     pub last_update_check: i64,
     pub released: i64,
     pub git_commit: String,
-    pub sha256: String,
+    pub files: IndexMap<String, String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Repository {
-    pub update_state: Option<UpdateState>,
-    client: reqwest::Client,
+    pub path: PathBuf,
+    pub content: Option<RepositoryContent>,
+    client: http::Client,
 }
 
 impl Repository {
@@ -81,14 +85,6 @@ impl Repository {
         let dir = dirs::data_local_dir().context("Failed to find local data dir")?;
         let dir = dir.join("spytrap-adb");
         Ok(dir)
-    }
-
-    pub fn ioc_file_path() -> Result<PathBuf> {
-        Ok(Self::data_path()?.join("ioc.yaml"))
-    }
-
-    pub fn update_file_path() -> Result<PathBuf> {
-        Ok(Self::data_path()?.join("update.json"))
     }
 
     pub async fn init() -> Result<Self> {
@@ -102,183 +98,88 @@ impl Repository {
             .await
             .with_context(|| anyhow!("Failed to create directory at {path:?}"))?;
 
-        let update_file_path = Self::update_file_path()?;
-        let update_state = match fs::read(&update_file_path).await {
-            Ok(buf) => serde_json::from_slice::<UpdateState>(&buf).ok(),
+        let db_path = path.join("update.json");
+        let content = match fs::read(&db_path).await {
+            Ok(buf) => serde_json::from_slice::<RepositoryContent>(&buf).ok(),
             Err(err) if err.kind() == ErrorKind::NotFound => None,
             Err(err) => {
                 return Err(err)
-                    .with_context(|| anyhow!("Failed to read update file at {update_file_path:?}"))
+                    .with_context(|| anyhow!("Failed to read database file at {db_path:?}"))
             }
         };
 
-        static APP_USER_AGENT: &str =
-            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
-
-        let client = reqwest::Client::builder()
-            .user_agent(APP_USER_AGENT)
-            .build()
-            .context("Failed to setup http client")?;
+        let client = http::Client::new()?;
         Ok(Self {
-            update_state,
+            path: db_path,
+            content,
             client,
         })
     }
 
-    fn ioc_download_url(commit: &GithubRef) -> String {
-        IOC_DOWNLOAD_URL.replace("{{commit}}", &commit.sha)
-    }
-
-    pub fn is_update_check_due(&self) -> bool {
-        if let Some(update_state) = &self.update_state {
-            let age = utils::now() - update_state.last_update_check;
-            age >= IOC_REFRESH_INTERVAL
-        } else {
-            true
-        }
-    }
-
-    pub async fn download_ioc_file(&mut self) -> Result<()> {
+    pub async fn download_ioc_db(&mut self) -> Result<()> {
         let branch = self
-            .current_github_branch(IOC_GIT_BRANCH_URL)
-            .await
-            .context("Failed to determine latest git commit for stalkerware-indicators")?;
+            .client
+            .github_branch_metadata(IOC_GIT_BRANCHES_URL, IOC_GIT_BRANCH)
+            .await?;
 
-        if let Some(update_state) = &mut self.update_state {
-            if update_state.git_commit == branch.sha {
-                let path = Self::ioc_file_path()?;
-                let buf = fs::read(&path)
+        if let Some(content) = &mut self.content {
+            if content.git_commit == branch.sha {
+                info!(
+                    "We're still on most recent git commit, marking as fresh... (commit={:?})",
+                    branch.sha
+                );
+                content.last_update_check = utils::now();
+                self.write_database_file()
                     .await
-                    .with_context(|| anyhow!("Failed to open ioc file at {path:?}"))?;
-
-                if update_state.sha256 == utils::sha256(&buf) {
-                    info!(
-                        "We're still on most recent git commit, marking as fresh... (commit={:?})",
-                        branch.sha
-                    );
-                    update_state.last_update_check = utils::now();
-                    self.write_state_file()
-                        .await
-                        .context("Failed to write update state file")?;
-                    return Ok(());
-                }
+                    .context("Failed to write database file")?;
+                return Ok(());
             }
         }
 
-        let released = branch.commit.release_timestamp()?;
-        let ioc_download_url = Self::ioc_download_url(&branch);
-        let sha256 = self.download_ioc_database(&ioc_download_url).await?;
-
         let now = utils::now();
-        self.update_state = Some(UpdateState {
+        let released = branch.commit.release_timestamp()?;
+
+        let mut files = IndexMap::new();
+        for filename in IOC_DB_FILES {
+            let data = self
+                .client
+                .github_download_file(IOC_DOWNLOAD_URL, &branch, filename)
+                .await?;
+            files.insert(filename.to_string(), data);
+        }
+
+        self.content = Some(RepositoryContent {
             last_update_check: now,
             released,
             git_commit: branch.sha,
-            sha256,
+            files,
         });
-
-        self.write_state_file()
+        self.write_database_file()
             .await
-            .context("Failed to write update state file")?;
-
+            .context("Failed to write database file")?;
         Ok(())
     }
 
-    async fn http_get(&self, url: &str) -> Result<reqwest::Response> {
-        let req = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .context("Failed to send HTTP request")?;
-
-        let status = req.status();
-        let headers = req.headers();
-        trace!("Received response from server: status={status:?}, headers={headers:?}");
-
-        let req = req.error_for_status()?;
-        Ok(req)
-    }
-
-    pub async fn download_ioc_database(&mut self, url: &str) -> Result<String> {
-        info!("Downloading IOC file from {url:?}...");
-        let body = self
-            .http_get(url)
-            .await?
-            .bytes()
-            .await
-            .context("Failed to download HTTP response")?;
-
-        let ioc_file_path = Self::ioc_file_path()?;
-        debug!(
-            "Writing IOC file to {ioc_file_path:?}... ({} bytes)",
-            body.len()
-        );
-        fs::write(&ioc_file_path, &body)
-            .await
-            .with_context(|| anyhow!("Failed to write IOC file to {ioc_file_path:?}"))?;
-
-        let sha256 = utils::sha256(&body);
-
-        Ok(sha256)
-    }
-
-    async fn write_state_file(&self) -> Result<()> {
-        let update_file_path = Self::update_file_path()?;
-        let mut buf = serde_json::to_vec(&self.update_state)?;
+    async fn write_database_file(&self) -> Result<()> {
+        let path = &self.path;
+        let mut buf = serde_json::to_vec(&self.content)?;
         buf.push(b'\n');
-        debug!("Writing update state file to {update_file_path:?}...");
-        fs::write(&update_file_path, &buf).await.with_context(|| {
-            anyhow!("Failed to write update state file at {update_file_path:?}")
-        })?;
+        debug!("Writing database file to {path:?}...");
+        fs::write(&path, &buf)
+            .await
+            .with_context(|| anyhow!("Failed to write database file at {path:?}"))?;
         Ok(())
     }
 
-    async fn current_github_branch(&self, url: &str) -> Result<GithubRef> {
-        info!("Fetching git repository meta data: {url:?}...");
-        let branch = self
-            .http_get(url)
-            .await?
-            .json::<GithubBranch>()
-            .await
-            .context("Failed to receive http response")?;
-
-        let commit = branch.commit;
-        debug!("Found github commit for branch {IOC_GIT_BRANCH}: {commit:?}");
-        Ok(commit)
+    pub fn parse_rules(&self) -> Result<rules::Rules> {
+        let content = self
+            .content
+            .as_ref()
+            .context("Local IOC repository does not have any content downloaded yet")?;
+        let mut rules = rules::Rules::default();
+        for (name, data) in &content.files {
+            rules.load_yaml(name, data.as_bytes())?;
+        }
+        Ok(rules)
     }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GithubBranch {
-    name: String,
-    commit: GithubRef,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GithubRef {
-    sha: String,
-    commit: GithubCommit,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GithubCommit {
-    committer: GithubGitAuthor,
-}
-
-impl GithubCommit {
-    fn release_timestamp(&self) -> Result<i64> {
-        let date = &self.committer.date;
-        let dt = DateTime::parse_from_rfc3339(date)
-            .with_context(|| anyhow!("Failed to parse datetime from github: {date:?}"))?;
-        let dt = DateTime::<Utc>::from(dt);
-        Ok(dt.timestamp())
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GithubGitAuthor {
-    name: String,
-    email: String,
-    date: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod accessibility;
 pub mod args;
 pub mod dumpsys;
 pub mod errors;
+pub mod http;
 pub mod ioc;
 pub mod package;
 pub mod parsers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,8 @@ async fn main() -> Result<()> {
         None => {
             ensure_adb_running(&args.start_adb_server).await?;
 
-            let mut app = tui::App::new(adb_host);
+            let repo = ioc::Repository::init().await?;
+            let mut app = tui::App::new(adb_host, repo);
             app.init().await?;
             let mut terminal = tui::setup()?;
             let ret = tui::run(&mut terminal, &mut app).await;

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -6,10 +6,10 @@ use crate::ioc::{Suspicion, SuspicionLevel};
 use crate::package;
 use crate::pm;
 use crate::remote_clock;
+use crate::rules::Rules;
 use crate::settings;
 use crate::tui::Message;
 use forensic_adb::Device;
-use std::collections::HashMap;
 use tokio::sync::mpsc;
 
 pub enum ScanNotifier {
@@ -47,7 +47,7 @@ impl From<&args::Scan> for Settings {
 
 pub async fn run(
     device: &Device,
-    rules: &HashMap<String, String>,
+    rules: &Rules,
     scan: &Settings,
     report: &mut ScanNotifier,
 ) -> Result<()> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -847,14 +847,17 @@ fn render_app_widget(app: &App) -> List {
 
 fn render_statusline_widget(app: &App) -> Paragraph {
     let white = Style::default().fg(Color::White).bg(Color::Black);
-    let yellow = Style::default().fg(Color::Yellow).bg(Color::Black);
+    let green = Style::default().fg(Color::Green).bg(Color::Black);
     let mut text = Vec::new();
 
     if let Some(update_state) = &app.repository.update_state {
-        text.push(Span::raw("git:"));
-        text.push(Span::styled(&update_state.git_commit, yellow));
-        text.push(Span::raw(" updated:"));
-        text.push(Span::raw(utils::format_datetime(update_state.last_updated)));
+        text.push(Span::raw("ioc-git:"));
+        text.push(Span::styled(&update_state.git_commit, green));
+        text.push(Span::raw(" released:"));
+        text.push(Span::styled(
+            utils::format_datetime(update_state.released),
+            green,
+        ));
     }
 
     let text = Text::from(Line::from(text));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use chrono::{offset::Utc, DateTime, Local, TimeZone};
 use sha2::{Digest, Sha256};
 
 pub fn human_option_str(x: Option<&String>) -> &str {
@@ -11,6 +12,12 @@ pub fn human_option_str(x: Option<&String>) -> &str {
 pub fn now() -> i64 {
     let now = chrono::offset::Utc::now();
     now.timestamp()
+}
+
+pub fn format_datetime(timestamp: i64) -> String {
+    let utc = Utc.timestamp_opt(timestamp, 0).unwrap();
+    let dt = DateTime::<Local>::from(utc);
+    dt.format("%Y-%m-%d %H:%M").to_string()
 }
 
 pub fn sha256(buf: &[u8]) -> String {


### PR DESCRIPTION
Downloads automatically if started with no existing database in `~/.local/share/...`, or press `ctrl+r` to re-download.

![image](https://github.com/spytrap-org/spytrap-adb/assets/7763184/b64ad81c-c566-43cd-8d01-a10d2b2940ec)

- [X] ~Can't handle watchware.yaml yet~
- [X] ~Starting the scan still causes a reload from disk, it should instead use the rules loaded into memory to guarantee the rules match with the git commit displayed in the user interface~