### PR TITLE
Update repro-env.lock build environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -58,24 +58,23 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -97,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -107,15 +106,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-compression"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
 dependencies = [
  "brotli",
  "flate2",
@@ -133,9 +132,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -148,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bitflags"
@@ -160,9 +159,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -214,9 +213,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -229,21 +228,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,18 +263,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.3.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+checksum = "586a385f7ef2f8b4d86bddaa0c094794e7ccbfe5ffef1f434fe928143fc783a5"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -285,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -331,11 +330,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -397,10 +396,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.32"
+name = "either"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -426,9 +431,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -453,9 +458,9 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -568,15 +573,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -651,9 +656,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -678,7 +683,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -777,6 +782,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maplit"
@@ -827,9 +841,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
 
 [[package]]
 name = "mime"
@@ -879,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -941,9 +955,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -962,24 +976,26 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "cassowary",
  "crossterm",
  "indoc",
+ "itertools",
  "paste",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1015,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1027,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1038,15 +1054,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "async-compression",
  "base64",
@@ -1106,11 +1122,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
+checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1119,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -1152,13 +1168,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1225,18 +1247,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.181"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.181"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1328,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -1349,6 +1371,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1405,10 +1437,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "syn"
-version = "2.0.28"
+name = "strum"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1417,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1439,18 +1493,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1474,11 +1528,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -1486,7 +1539,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]
@@ -1637,9 +1690,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1820,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1835,51 +1888,52 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ anyhow = "1.0.44"
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.2.1"
-crossterm = { version = "0.26.1", features = ["event-stream"] }
+crossterm = { version = "0.27", features = ["event-stream"] }
 dirs = "5.0.0"
 env_logger = "0.10"
 forensic-adb = "0.6.2"
 hex = "0.4.3"
 indexmap = { version = "2", features = ["serde"] }
 log = "0.4.14"
-ratatui = "0.22"
+ratatui = "0.23"
 regex = "1.5.4"
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls-native-roots", "brotli", "gzip", "deflate", "json"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 build:
 	repro-env build -- sh -c ' \
-	CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
 	RUSTFLAGS="-C strip=symbols" \
 	cargo build --target x86_64-unknown-linux-musl --release'
 

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,21 +1,61 @@
 [container]
-image = "docker.io/library/archlinux@sha256:6568d3f1f278827a4a7d8537f80c2ae36982829a0c6bccff4cec081774025472"
+image = "docker.io/library/archlinux@sha256:b29dab0d5f362cfe2ed4662c46f27855681d56fb548fd2f6d927fd573131178a"
 
 [[package]]
 name = "archlinux-keyring"
-version = "20230704-1"
+version = "20230821-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20230704-1-any.pkg.tar.zst"
-sha256 = "6a3d2acaa396c4bd72fe3f61a3256d881e3fc2cf326113cf331f168e36dd9a3c"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZKPPXgAKCRBtQr3RFuAGj9oXAP94RQ1sKD53/RxVYlVEEOjKHvOmrWvDkt1veMYygnlnIgD+MLg/TT6d71kE8F08+JH+EcnG7wQow5Xr/qBo1VPLdgQ="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20230821-2-any.pkg.tar.zst"
+sha256 = "1adcb1f1599b24ff357573996e4064ba9155f90e7998c3289520f6d97ca20189"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZOxGUgAKCRBtQr3RFuAGj/MKAP0e96Vs3RkIBXDQW+WaMlllDmVe7Sze6Sc0IOQqhLyk3QD/fS9Ldoan80/NQJzDlCkd+KjIx6U8VBiFwv1++WHXoAM="
+
+[[package]]
+name = "audit"
+version = "3.1.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/a/audit/audit-3.1.2-1-x86_64.pkg.tar.zst"
+sha256 = "2f82b4e4e4e38132397a4a5bfb8a1b2d45a7a522473e8e841fdbf965d634efd8"
+signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZNDHzAAKCRATmwnaW/DTOGQVAQCKYLj2qV0KLiw7R68hgFj+2i5Apj5N8eYRogbEfPs0+wEAxWfjineCRRM7AR3TVACspd4I9gvhw47mD+bmF8y4zgw="
 
 [[package]]
 name = "binutils"
-version = "2.40-6"
+version = "2.41-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.40-6-x86_64.pkg.tar.zst"
-sha256 = "b65fd16001578e10b602e577a8031cbfffc1164caf47ed9ba00c60d804519430"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCge2AQD/LGBeHRaeO8xh4E/bAYfqd1O/OFqk2DrQBJ73cdKl2gD9EC8p4U/cXQK8V774m6LSS50usH5pxcQWEq/H0SF+FgM="
+url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.41-3-x86_64.pkg.tar.zst"
+sha256 = "b921c57f7847a3daa4025c961cfa573f1f5244e9f84e673edba4fc4fbfd09a70"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZM0fcl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjWSAP90OJtRaSrRM6tQAaNseK66rjp/UNeexmEGKk3hVSAHOQEApYk913azGyXlSJCDu6NpPJXII1BcBnuR/62p4KpSuwU="
+
+[[package]]
+name = "ca-certificates-mozilla"
+version = "3.92-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.92-1-x86_64.pkg.tar.zst"
+sha256 = "0deefc5884e37867e608df6eb440846b21e9d4bf12f1ae20088a149703e5acd2"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZML0wxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8c33wEAh7y67JJL4O5eHLbBsDjb2U1f44Ek7WEYFBEWazNmFugBANqH3H/8tF9p8jVXstp5x00MREtFw+T+jhraOIjqh4sK"
+
+[[package]]
+name = "curl"
+version = "8.2.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.2.1-1-x86_64.pkg.tar.zst"
+sha256 = "5ce8b218ecbc75a097b683e81fe901b7e144064ceeeca073fc8a0ea3b0b2ce4d"
+signature = "iQIzBAABCAAdFiEEtLdZYl1GM0MLdIdwWeQ+EGskc2gFAmTA4X0ACgkQWeQ+EGskc2hvTw//fLUtrOsXvDMDclh6vwccHz9uSK2EpHNuFTpyd3Jx4bK66ZwePTIgMVgNJxmnbso77G+eyhb4QpCTuu1fJdSrXgaVqAYR21uWNuHLVKSyT9+L7LvSbnXdhMzGLLN3bY6UqfGirSKMQOOLXsxUFvCHovqHkspjbXLDejJA/eGdIBx2V2BoDa5xLIXz2QDAPuevwMBrHv+C682uiEr/5ihmsn363K9TX+9B7Pbreu4FvY/tnMMkzeG0+NiuylLbYz3egkZwhFO0mX9ZgxzkUOx8Bx/qqK+Slo0bIYNI274Iz25dexq06rbEFlOp7DM1b4zMYCDYNWI+RTPX0RbQXOJfoX+AhwLdZvf9pf3cT3BLpIaCVrWNI5nPd/5+aQY0tcY1y7A4VA+66/melwtDB17PAKengdWqjVs3BOtBRs1aT4Zew4RmNS1n5NGarxCJM/yrzPC0Xz6piE4atmf1Fzaz8pRViVVejUk1uIFqKIUmtZtO1qSkbeTLRE/e4orVBfeasYlaUsCBtnsHMeqYy9BK2a+IvLk7o17trlIP1niFuIqbXexu+rusPt8Wn4IQlZvT+dyWMcRP4OFBHAECieE5GaoWPcTScFDOifpdPk7FShXX8C441xcjb0pomGSW/JFBKD1CSlMuUVhqF5p/NkE4smP+yKrdHOYtqo1LdejItaw="
+
+[[package]]
+name = "device-mapper"
+version = "2.03.22-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/d/device-mapper/device-mapper-2.03.22-2-x86_64.pkg.tar.zst"
+sha256 = "1a717b916b12852a2a67f16b201a392a4adb3f3e06fb77c054a76608c7e0198d"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNs11wAKCRBtQr3RFuAGj6JtAQDHb4vbPhK28J2wwI3HcgZXUt5cmmGXS8uUCksiyR/ZUwEA4qO+sVVl8X4aATWtMUZUVNWQcT72v5XFvmc2TbAUPAs="
+
+[[package]]
+name = "file"
+version = "5.45-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/f/file/file-5.45-1-x86_64.pkg.tar.zst"
+sha256 = "3ad37e246e893cdf59ae3af862d083c52087c47d3e6210996075ce77d41c5a1a"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMLglQAKCRDluymEcK1OQb62AP9hE3dXkRFkEUgk+qhvr2G1YPDwGJq74nOouLS4U/SO+AD+O3z89uX6mLEdf56VSygb769wpeUwt54vTvNJy11qGgI="
 
 [[package]]
 name = "gc"
@@ -27,19 +67,51 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZHH0pV8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "gcc"
-version = "13.1.1-1"
+version = "13.2.1-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc/gcc-13.1.1-1-x86_64.pkg.tar.zst"
-sha256 = "cd3a7e2bac988547dd3f25112ffcc8350650e2a9ec4db8cda46466dfc0f2234a"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZE6DcF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCrnLAP9ijGUTktiXvtQ+y7kMyp9RO3JGzuEca9t/rKNC9WekdAEAleFfXSruq7Lo4iw25nlJ29GDpKlwTPQleLMO7GonIA4="
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-13.2.1-3-x86_64.pkg.tar.zst"
+sha256 = "c28a0e0c90a9f2c946b0e3c969742eb872229bb352c44e943e6aa101f60c7d04"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMoUtF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCouZAP0YU8C2MiqVEgJF2sJUVBTjphdU5qfPLTH4wTfrqYaJ6wEAiFydzaI9ORiQYQ9Y4SH6aHBD6S4BN+gnm0FjDCWMxgk="
 
 [[package]]
-name = "gettext"
-version = "0.22-1"
+name = "gcc-libs"
+version = "13.2.1-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gettext/gettext-0.22-1-x86_64.pkg.tar.zst"
-sha256 = "6bdf793ed199a833cf4a4ea7e7405de59d48206a119872d2b02f27852ebff0ac"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmShNVkACgkQdx32Yn7faB8pEQgAgy6mzXvbIl5KTRqpVT/2qHK+Tk/a+R++fgw2KGk032Gh2+kbkQj6cBHRla0Bh//ekGTj7pENlmSNGCp2bSnHcZt2cIg2Jm0oi6JOcuVtsB83wMDSRdtMr2Sb8wuZnG/nmTJotMkJ9hHq5Q4I5VmBSJwoc8sKQWrQX+ElXPvBJ9mY5ldvAxYCGnTZCzvyh2fepB5MQBc0FTEEA3X32k+cb8zjwTDuDFS6LmcHbm25sZlC8JfQ3m2ZGUiR4MrQuouWml8WyJldZeatsCdNHxZ23kI9mh4DTzd7ipshUXrhDi5cN8oOMA2xAEaVkspAY9ifwMKsj/BXxaGldxEKaTndSA=="
+url = "https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-13.2.1-3-x86_64.pkg.tar.zst"
+sha256 = "8d4658790a832599b38c6403ce669d19f64fbdaddbe59c30213b192b898459e7"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMoUtF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaChntAQDCHJgEmLOk2LdTlOYm5KFVTxoN2eOOy2R2ouWLc7TTkwEA5zyEqic/i3v4buMRdb9TrmEO1B7ZQPtKTYNwb1R/RAM="
+
+[[package]]
+name = "glibc"
+version = "2.38-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.38-3-x86_64.pkg.tar.zst"
+sha256 = "e85b4e50da81bb80515c95093d5c3dc38c5428d7d5a3772eb0d9a7a6210f6748"
+signature = "iNQEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZN5CFl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmozAQD9JOoMGJnvTVyTslMXKFtS6Ria11NI0X3k+X3mmSjEogD48N2v4SrqQc3O0Q2pdel+VZudQuimI7ET/m15yicCBA=="
+
+[[package]]
+name = "gmp"
+version = "6.3.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gmp/gmp-6.3.0-1-x86_64.pkg.tar.zst"
+sha256 = "46ca028cb30a263fc5163348ad057a10b363dc5c6a59ff50b2fa5dd405acf755"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmTGonsACgkQek52CV2KUuRyFQf+NB0IJ4L3sXM03JCMQp8jIjEPqmeLC+VYm5jRJKqFbs3++vpMdXEK5vX9mMdqSA1UtmJRllEDX0uabUkr8msO3ZdzvCG8GmgzeZph0cafDlUVTR6Fk2wRklCuC06uPt6ko83pTfkvLd6MTT0Hp6KSes/8tCigKsIv0R+Uqqj8NpJTiGUeKtMoSZxlQoB/1yiEdQmXRT6uYgiRj5kEJ9SE29gBzH1Mve5uuR3Tl1DXbuMDeXs2THjk9xmz964bSNxFqVpVy3/85zVsGkNcDRZIJtXyrzeP9PI/FQIF8taaE+4ATaZjOT6J7rP7NCnr9poAB2ui1W7Pr2u1FH6ZrTtHQQ=="
+
+[[package]]
+name = "gnutls"
+version = "3.8.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gnutls/gnutls-3.8.1-1-x86_64.pkg.tar.zst"
+sha256 = "f951a1d18e25d3008ee5b1ac72742a57125b72fde64318918bdcde0bf7dd9743"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmTYbEYACgkQlGV6sg8qCStIjAf/eWEZhvAtE1FzCStUaZ+UCjBwTm3NUb2A/xtpilvDzL6VWCuma+//6Bo+nGjUbCd/0jZ6LS0miTVjrweBIYIOeUqAJRl1B7g8KGu301D69stj4mGpa3oVcWZlTkqHPOeOl9gyLrWFg1Ms1VnPhjNnYHxk/9N/bz2K8Xr843woelzOBE99huUsZ+iVcVHUHobHCwhgf6LrDy2SMXvjNHGt1kRFq0J7QRvCD4JwjJTdw5fXay3mL9hGbGUqYPiVcUPWIVI+OCaLdHRGPto9BEbCjF3MGBNFsN6ccCgJ0lVAX+L6w02IL6y4ehjLki75ClM0arog3Gr1p6bOCkfJ7NpRaQ=="
+
+[[package]]
+name = "gpgme"
+version = "1.22.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.22.0-1-x86_64.pkg.tar.zst"
+sha256 = "61bf13c95502d5955eb70e52ef65f64d4e3a19c812c2c01e09c74c8ae753b4ae"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZOPkLwAKCRBtQr3RFuAGj4myAQCYuSucvgYfwXsFy44qb4yssDwSu7IX8Lq7JWXxp7WO9QEAnhfFyLc4KxIq/DID0SQGrLv2wmATWRPvpuGm1FreJgU="
 
 [[package]]
 name = "guile"
@@ -50,12 +122,28 @@ sha256 = "1c17a7b5c3c9c6ca580c76b36080603587bd2dc39a2c3cb0f07d755da05126ab"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCY9Gy3F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCt5aAQDMcoBQsIEeLWacejGD+7TLT6F3Nu1Q3KDaNAZojqkwmQEAsvIVi/edva/VSJY9fHvmrcdV7jJrRjqglpWinxuWPQI="
 
 [[package]]
-name = "hwdata"
-version = "0.372-1"
+name = "gzip"
+version = "1.12-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/h/hwdata/hwdata-0.372-1-any.pkg.tar.zst"
-sha256 = "8f74a45fd6bf52cffa7ecf55f57c0843a9bb02670982a570512d20abb0acb915"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmSiwZ4ACgkQdx32Yn7faB+GJwf/aV67WHBrsA+jFl2dldxenTcjPKeJVq7EcSLX8dbt/WVT68IZpCoVAPtMKri5gkF97Z+L/h42/vfhzHq9DSVhezWQl1zPgYltXWviU9xZC2wGOenJ7PLDKjnsGESnBuGDS7M296efHpiDD2Os7h2WT5B2ZouPSoxRMDlimVmbCtFBZ3VD6nJ1G9NEc4Ee0IMvnlLoCaOiK8liWB/yfRpL0DP+SMfJtWeujwMw2/QxdLWHvvpOQI5WEi35Pd8l5DConQpyCYE/Z45N3MrOslqzi071gqXRENHAHc0cl9fzjSR/FT4lZgNEcYQi2H3HuZb3NJyBgEGpfAScVQYhJRXVlA=="
+url = "https://archive.archlinux.org/packages/g/gzip/gzip-1.12-3-x86_64.pkg.tar.zst"
+sha256 = "4204ed3a9c24398106d6c81e5a874e67e3c840b7329b741c8f16abdbcc8086c2"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZNs/vAAKCRDluymEcK1OQRQaAP4w0l9NcTg8JRPrwAn/bD6Vc2RV8SHDl/i8kh3LsudQSwEAmJP9INIasKE8AkxNSWlXxdA/lRAtSHx7h8KQp77Ubg0="
+
+[[package]]
+name = "hwdata"
+version = "0.373-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/h/hwdata/hwdata-0.373-1-any.pkg.tar.zst"
+sha256 = "97aa59b40dd132a8775d71b46a3d8f5abb2100ce19f8fd2c2baff6ac7c74a899"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmTcaBUACgkQdx32Yn7faB8mnQgAkRXu4n18IBCftQPM442cDtxVWuYedXPlwpSIE/IRVCGNZrZWkbUswpZBNelHaIhkFnrRIvkcHsV2yzfNlojaIhcMSE7Rjoqt9ulhSN8acwtPimbZ1X8BkSESFuautaCnzzH+d8YFiatc3xr50lfwDx97w5sTPew2gvIdugBo4WbTPCpePuMRzYRNoNSVN027CzWq93qdOr/8okJyiL7CyBoe1dHym4kuWgeCSYmZYH49lMgdBFN+CDS0QrtWlk0soXnj1OfKGVCBQa8vhDrn8HwinKU3LxDd3r0s+TVJF5Rdk0+5xOuw2qLyHfk7e7x/6OrIeEPCKoT2btw7SjpEoA=="
+
+[[package]]
+name = "iana-etc"
+version = "20230803-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/i/iana-etc/iana-etc-20230803-1-any.pkg.tar.zst"
+sha256 = "c841ba985e02663d9d37df08718639c94f0d6f878a67931d20b8d4fdb2353dfc"
+signature = "iQEzBAABCAAdFiEE5JnHn1PJalTlcv7hwGCGM3xQdz4FAmTLqnAACgkQwGCGM3xQdz4+xwgAlpkqYxZLpdts3WAi34V/eEQmqgnV2SoaeUvyIG6zly4GMLHbJbXJbmu/gN6MTlCc11sFGyJhA1MspLOs4WDyeQTmMzGQKgC+5YaI11mZR52YNzSXjEN8UuxA6cvK704gZbcaBS8D5+FeS7fG8oVbbUWLAv5JCsvP0I7aLKTlAx1tKuaKS01fsfAOI71sBI4Y36mhyHNRhD7jsXPWRGf0KcSVZqrrIsIYwlFsDAFDQa/d77Y4NgaRS0NyX4I019Ubv5rRQbR5yCKngd2732d03mlQoG6EzkHCkRXD9bU0XU0eDx9UCwuYZhrDjrI8uylpA0duKL3+9IomSycjncs7JQ=="
 
 [[package]]
 name = "jansson"
@@ -66,12 +154,60 @@ sha256 = "de45a1cfa23faf16681b9809c4dd375549268b19dd37fe23f96ef8717ac35095"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmJyQS8ACgkQek52CV2KUuSqUwf9H9g/0lroLE8fHR7G3Dcy4OILPGZPkt5HOiJBYdnhi0eWJyetHRCSFsMWiZk9HUJHoVbZH28Z3F75UQfI3cWAThSz1HzUMGvEWF/uTpOKENiwY4egQ0pA88eX6kvTt0BuCLA6JZso6VBz2kzYue4uV/B6otdStx6wf6AfDAIha1jWTButBv/pxpAcTJOp157S4Y+NO59NSn672iTm9CQxWcSSo6Bxfimu86kjceXTj/HK+aZ1onjnD7jtOjsrQOBO63thwouju8yNyD/yjeXzOw5KgsZ4c7gu0Wg10MlcM79G2EYXWFbq5/ARxBkEd49fYhDWaPriGz8bO9ri41vGUw=="
 
 [[package]]
+name = "json-c"
+version = "0.17-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.17-1-x86_64.pkg.tar.zst"
+sha256 = "fd4716d60ac5bf7961aa07c9e63b9bd317d3a2be3b88db57d5f2c8f1f1c2167a"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZN1WYxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8coswD+P7MnDLKmZCB5Ui2+9Jac0YXC+OsoGzMx+wm3HQdTBPoBAOODlHBaMhAn/sMbx3I9tWtgv3cTgmQaCsUptA4n+UsC"
+
+[[package]]
+name = "kbd"
+version = "2.6.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/kbd/kbd-2.6.2-1-x86_64.pkg.tar.zst"
+sha256 = "1646675f85a262a742d455eff2f7e8b16f7d15224e73acfdc2990bd559902713"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmTb1Y8ACgkQdx32Yn7faB/N2Af9E/NBIONAexX6CyCfgOtoylodUA1GDddJPHDPB2pLidCNiMe2Vu9KVdDaAnCjJtFTFUYskBYK16G4FShiYKYrETveLjTN/dWc0BETkgtabynKnr0wJbsJIMCQs7Y6LSgL6eMoJ2ZMX1RIT58ltw+l4km9zu53jeZFpVWRHXoQGDOvvuhcn5a4QElCS/RE3A3CkuXU/DDwPCnWN+e+TWdtQxqpy2GmwdDaPbgjZUhx5cDQjB7NTf0SzVGKg1k17x2dOQ1Z2d6K4mt2yhrSP2rAQd3twsR5C0Kq2Yqww4lhfgqfow+mNhSO1FA/U4+yAw4Re8vpYqo7Rx3wkfRAcKxszg=="
+
+[[package]]
+name = "less"
+version = "1:643-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/less/less-1:643-1-x86_64.pkg.tar.zst"
+sha256 = "aae0ee2cac7ef0072ed6485be1da7dc4d3cc6133e62776b1ad5878e70b9576f4"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZNkPJgAKCRDluymEcK1OQRy7AP9gFinh/AlRaXm+x1PClNEO+vLRcgnP6nLtb6jHfGMQHgEAw7SbyKHfOcES7K4kf0b/gHaSs6C5/x0U+/OC4O1R8gI="
+
+[[package]]
+name = "libarchive"
+version = "3.7.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libarchive/libarchive-3.7.1-1-x86_64.pkg.tar.zst"
+sha256 = "45a349269935d77bafcd06e2eb40189a44c34cc5a8e3b18723fff0f24265783a"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZMVyZAAKCRBtQr3RFuAGj838AQDIvKjbfFO7spRDeC1wa6apKxgZWFhW/3Abh4TOW//KVQEAmLRmxFw8WvszRRGnyi/Nga8D1y4Q94ho8nVc/vevuQQ="
+
+[[package]]
+name = "libbpf"
+version = "1.2.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.2.2-1-x86_64.pkg.tar.zst"
+sha256 = "4fac3eb81e78aadc86861c7a09a0e7b16db2ffb019cc58ead1f97b64a8d4da52"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmSuQ4EACgkQek52CV2KUuSezAf/QUjML1JBbeQ7iHISEinbQ4f7zPJPGQHvPQZlu5yHlKew7yS6F7BPPm5bK8BCJ9xK4wENuMXvjdwxbNMMTPJPRUXJV/JqGjJVbnu1CacrvF0jmfCUoEZfbe64ZzCmgZFSev7UOxgl2EhwoWqDwdH2GmbEb/wEurv4FMio+/+31sQsFKhvz2KWl+ugJSea8RXCeQQyTKcZVYXeRgMzoaZzFruFLgvw2mgkGZ7p5ut0z20iDSQCFKOHiMq/qoj/MV1Fy3UGS4caqBCUitGdY4PwVdzFxoe2WFcheWrkapeYn6wU5UVM8vuMieAX1mMq4bCJBUT8McD8Hyk3wpKwtd80VA=="
+
+[[package]]
 name = "libedit"
 version = "20221030_3.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libedit/libedit-20221030_3.1-1-x86_64.pkg.tar.zst"
 sha256 = "4d6c079024014b5683fef2ed27f82b3c0ca066bba52d4817446ce8161b89f69c"
 signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmP45h8ACgkQ/BtUfI2BcsixEhAAm17WTFd0KfIioFmLRtJCHD0w9Dk73Wtfo9dMDX2UEkotFhwvnbaEehYmaVIUQKH05dm8c7mAH/USTZxPU0IknBIgX6cy9t9rHsKND87FkgzmvLvJaryoV7UKCAwWKinAKxjjixJvIav+/3aNFf6DflMp1jW3zxRy+71c71bc45NQ3tYg3t4/1ChtZ+y/Gf4SplJlzWRZ0pI9qh2EAUJ2gdG7hnecHc+bEwRxCtte5CxqgAT+axrred1Ko49ZSmvWK835DRHWOfYghKEA2Dxh3gdLgy/5Qv1wykRgQ/O3ZVeCzprBtI1xpJIy3dasuRne3FTvBBCtYipE/id1wx2hrj4kkw1U0QXyGYkjvIDHzMuIH7uG7DA9fZ2f6ufWpBx3LhugamB3tnMw4VmoCxxBkMEtSWozX+ZLr9IdyXR3JEcHxhAVZdVGAT6pEQmVU70/9ZJsUPK7ZRsDjhYgteU1Dq7MMq1py43jIEe5Pj6r1xrDi4QfD+O6ID/SCPlKuiVpsJXLuTCK2Si1MXucN+R+AbNFO0Y/WoQzBEB0/P+hp/isHtI1lgwP9ETx7qJpP2pFeoVqy/YuJDhv0hU7Jr9pOorjYeTVhLiw7MfWr7ySmqkGmLQR1gESYDV2E3ACKGYnSlZ3+sA8YypZvLHCsQ87Vw7geNUKG839RIVSfeQsqiM="
+
+[[package]]
+name = "libelf"
+version = "0.189-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.189-3-x86_64.pkg.tar.zst"
+sha256 = "4e515e410f2ba7814043ab4a25dd4b93b040408cc69503c60fd4e33e2cc0edf3"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMpLsV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaClJZAP4n+YyxUN1YrNlV77DP6PSHTY6Br2KIBxeHyfA7iYo1RgEAmIhiAWEb0wAz9Es42WbX30gzMKv4ZfsCXkNHA8W1GQY="
 
 [[package]]
 name = "libisl"
@@ -82,12 +218,12 @@ sha256 = "b6f495748d9c877c15e47e9691e09d86139cd234e1990a97c531d8d8c9f993b3"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZCq2IV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkzKAQCFNdVbwWwjQ8+Ba+iGYklKxxlcAJoUXYPsy1OChLCUpwD+KsxGh2JyiO1aP5WOmsDBRXhqNB07z3dNBVwNL6GwNww="
 
 [[package]]
-name = "libksba"
-version = "1.6.4-1"
+name = "libldap"
+version = "2.6.6-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libksba/libksba-1.6.4-1-x86_64.pkg.tar.zst"
-sha256 = "98520cb2a40b35bb596ebf92d531ef1a2d3b195648ca4ffc8850fada32150397"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmShNmIACgkQdx32Yn7faB/Y9wgAuaiOoz/IWtUL55w8mGRRuyBSXLU2fhQxd3L2tio2A+K6nJBAxmQd60a7h9/bPo7de1Rbnf0yVgcvT23VhSRlCILRbmSK5jLFgCu8/VFqFAG2g4qy/ZpqjPSaRYw/TrDJq7utFaQ1/clBYqG+Ie/m7cjo9q7qKLG36EMyK4pGt2ysVinrm7sNqQMt16an8LeMywL+Z/I+Be2R5IIEOH1VWJCBhcb0N+66POlJH4jBDnA3HhW6kcyRpY3r7Y87wuqtVERWVxXFUSdSqxI7+PCQKB0mG6WmQ7aUcLdTwpVjECve+1FC6Ci9GUD+/FyGNxVGCLidobdrrw2VZgWeo0JYbQ=="
+url = "https://archive.archlinux.org/packages/l/libldap/libldap-2.6.6-1-x86_64.pkg.tar.zst"
+sha256 = "9b5f8d8fb5e326e5502fe7a5cf46f47e0e2f6a8f0d4cdd9285de2bb5f4cc60fd"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMg04F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCvAJAQD5Qq+gpBAm3uikxCf4e7q4i9g59+3Nij/Ywxt/ezEq9AD/Rq5squhhvxY8DaUQ1gnptVsMgFmvgZwkFKD7b6lBAwk="
 
 [[package]]
 name = "libmpc"
@@ -98,12 +234,60 @@ sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
 
 [[package]]
-name = "llvm-libs"
-version = "15.0.7-3"
+name = "libnftnl"
+version = "1.2.6-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-15.0.7-3-x86_64.pkg.tar.zst"
-sha256 = "1dc2ce660bff783a02e1e5022ff4cd73917bf22a81038ec9443d3c6c4463fc2d"
-signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmQxBQIACgkQeGxj8zDXy5Im1Q/9FRCsXHIBGMIG77v2YRqjFA4JgcHTMjHDmSEER/WCVzFJSx4lhXO6v033DqZkODl7osVNto1KsNP4BTMJXkVR+KwrBAgoDTg5geruc5kZ60KkkmAkRU/7puaRbLj1uuoODVcAV2IuFjN1ezS3LBP9O47rfzcAP9GhR7Xrfa50ozX7w1HsfEV11MAujI7sfNZTn94/HdkQfZt9Q63+bniI+B3XPbR888sVbvEquQNISPYpGTPELDRlcJk8/Hf9USQXtIPMlpDLoYaQG3DT5zuI5DjgQKD/YugbehQQNsLZb3sKrygC+8hVSiY46QIWQgjBzJp1Ovk2ge8sofW/qlh8Z4CcqVQICtLj67xq57Y4L6DA9XsPwSe35y7fyspU37ikisQq/ssjyIudOqeWIhOVGmRBoQHhLg+ISJSGZodBjSwjor/RBa1wy9qE99a6SUXLnWBXKjFMHKcZwD/XewcR73QQdOFaT695AG1tz/QPleIMUGnJwVLdS4bBrCSeCBqY585GzubSErglPrUMeQZOSq6TGpK9PxJuK785t6DL+v4r1Ipzbi6etVU7GZUdOIS4xWbH+nPY/qFOB8JeJatK6I0IOOh/DmvJsXPfQTAcOnDuzyJn+enhd+cx2te+FBLu1z174p6iexf+Vh7k6DjH0fYCmoGJnLnRVlmgB5GGW+g="
+url = "https://archive.archlinux.org/packages/l/libnftnl/libnftnl-1.2.6-1-x86_64.pkg.tar.zst"
+sha256 = "7a1756a26ec062d051d081d60e8dc9bfd9263d4fd5b2ecaaf1092356d788243b"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMGObAAKCRDluymEcK1OQYNgAQD9K9QerwGTw07xPUO+w+HC5fbMOfWIIIWQBgnOmhIS9gD/QCC2zr6J807yqzDUdsbZo4vNdR3ONWn8k4QOyQdEJQ4="
+
+[[package]]
+name = "libsecret"
+version = "0.21.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libsecret/libsecret-0.21.0-1-x86_64.pkg.tar.zst"
+sha256 = "86d849a17423384986f60625edd95815a3a75bb79bb7783ec5f863bf0a1619b5"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZNVr3hUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8eUUwD/e1DDq2T0o3gxt8IMgVUmqMVma7QEfYGGWqWHV2n2j1sBAIXFgi85T+Z6GkDlpPQ7gfZLHIOfpSiFePWFVEphMVYN"
+
+[[package]]
+name = "libsysprof-capture"
+version = "3.48.0-4"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libsysprof-capture/libsysprof-capture-3.48.0-4-x86_64.pkg.tar.zst"
+sha256 = "afdecbe78e4214421e343eac2888784cb2a43cc1838a28686e6dff96a14da5cf"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMpKGV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCqfkAQCd9gPE8PUWDwoEGEMfB/LEJB/H54zIaCONDSiX6s6Z9gD5AV+WnpquGv54nP0cE9nlNuGXiFw3lj3tmrh5oMgPKQo="
+
+[[package]]
+name = "libxml2"
+version = "2.11.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.11.5-1-x86_64.pkg.tar.zst"
+sha256 = "86f75735ed68ea7495687560b850c2f5d3f369f5277283861182ed8c04b6b780"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZNO5SBUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8eHzgEAyglj11Z3oMKUPCH0s56YcaXMJ2hfUyKQ1iFY44JOCeIBALCcqoNFri1qNInH3dzWfNjlbsmZMU0s9cQ8BVSS/bYB"
+
+[[package]]
+name = "licenses"
+version = "20230729-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/licenses/licenses-20230729-1-any.pkg.tar.zst"
+sha256 = "0c7f90edf074a40697f8c8544c0c6e932652f27c0f2d8cac1e986f9041cc35e1"
+signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZMZOlAAKCRATmwnaW/DTOAIpAQCNqccRY6pm1svwyKkrgKQLDC7yPmIIl0/IyZl0bTHl8AD/Ur9VloLPnoQ/d2NN0QO22lsWNK9b7ewl/aHH/FrQUQ8="
+
+[[package]]
+name = "linux-api-headers"
+version = "6.4-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/linux-api-headers/linux-api-headers-6.4-1-any.pkg.tar.zst"
+sha256 = "93d28caeeacfcb6a93e5b1fc302b404f8a3b28a700fee675469125237cc85d44"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMZ9Q18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpkWAP0Sp8VVHIjFGF2FVlY9WrqnSQPqXxuHbZlQI2impL/7aAD9E5XrM86uq0nhKIoL1P3O+4ByiIz1kNT65JB4or6moAs="
+
+[[package]]
+name = "llvm-libs"
+version = "16.0.6-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-16.0.6-1-x86_64.pkg.tar.zst"
+sha256 = "156a44aa81be475fec8bcb96f6a5b68a1b3e9d27304caf03f79386565679bf75"
+signature = "iQEzBAABCAAdFiEEhs/8qRjPOvRxR1iAUeixSKmZnDQFAmTfjB0ACgkQUeixSKmZnDQFBAf+IXPoe66l3tJD8buJN6S8oynw01J7OcqyhESgkZ6V56hBHjbbWNAhe0e6B30FABZWAXUveihA8yr8kuJJhpalDjfrEPG5rZ69ugpGlhmBhVF58Ao1RtYWBy3khhGjAnN8fC4g0JTYDUB5zkqbxN6f7k/WHQbeZQUvl+DPlpmuXL1hILBSiPzKd6FooYAVLq0yOfXmMvq8OpW7QTlRcvYErdNc1eCnvKBqvs4+JfIkPdFW3L3MUMR7SF/qddc03ti9eRXfXw6HCgfYU+j1nB1nZcOaGwZHNV+mAaFQsb7Y194BZ18LFNvatYP4D4dpAXdsFyvp5ACWo1szuxa1hQEs+w=="
 
 [[package]]
 name = "make"
@@ -114,6 +298,14 @@ sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
 signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
+name = "mpfr"
+version = "4.2.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/mpfr/mpfr-4.2.1-1-x86_64.pkg.tar.zst"
+sha256 = "29380ccc401204b20aa00da6e9d4ae01bfd90eefeb70f4ba872d401fa3f7d70e"
+signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZOWwkwAKCRATmwnaW/DTOA9gAP9lFt+4nOS3ykwd+zd8HWj3VkBRGUQalLW2G+B7jsx8RgD9H0X9RXn00f3dAoDdI1WenOz4bxAXZAg0bwLCpfrAeAo="
+
+[[package]]
 name = "musl"
 version = "1.2.4-1"
 system = "archlinux"
@@ -122,17 +314,105 @@ sha256 = "f585ddabdfde5a29b88193827ccc597f74feb878723da9ce813d882c956e19b0"
 signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmRRZ5gXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1VGhAAwoRqJgoycDFQInlZtrXoreYRhFdIJhknGCtsAWgGvYY5CDrEXQwUR3zHpYahzka6CbAv8aZdL67CIZELQ55f22xFyAIyeBLGl21QsI/A3Isom9+IVrOOsIc1+Z5LNp1LTZkAPiK1j06NWkaRpzL6NaFeUf2ziq8q/3lDfXaalyTmy6hV29ZMp8Gsa0gcsCtremCNJXVRwOB5/Hs9a0YJwOheNHuqEc6Md08N5rrE+HkTxMJB62FZn9ta1UqpejnvLBr5Q5yNKFsDuc67ZY6AIBlS/x2iyPDidvzbULj+5fs+4wllkK0svUCUHcKjBjFazCMX+bzS80EymuyzB4dkPxAxJ2/RVsXvFkhquKzAcFEOyZ/CiJiaRfeTZHzcmA1u6tjcl2wopc886wJgX08YqJrlXNQ5jbgo3jkHCUWlVYau7IF9pb+cekgPX6ut+n4ZzZUbaP0yahmzZq5gPsdHf0uKQoVjgxxGhWz6mrllpy/EeKVks0bj/fiHE9Czn0naLoaO5Y5ww25lg3DrAW3GfgTepRW0aXEoecDM9izGkw8D+BqUyV79z7qE5El/ndymyL8dOxzIFIMNFJePzg2E/Av7inXMV3H6gFs6Tw/LmbzQVi/RRO6k4Bill3Md9udh+0waEa70Gs9n2dxNN4C8R1ubeA2yDzQim0ua8caOmT0="
 
 [[package]]
-name = "rust"
-version = "1:1.69.0-3"
+name = "openssl"
+version = "3.1.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1%3A1.69.0-3-x86_64.pkg.tar.zst"
-sha256 = "b8eb31a2eb80efab27bb68beab80436ed3e1d235a217c3e24ba973936c95839e"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZExVKBUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8fQkAD6AudRi2qP3WxSn38OOkSRSITciqRevPaVJgrz03JUBEAA/12h9z8dReD07Lqnltx9QTa3Cxppbv7VpJlTCQuavoMG"
+url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.1.2-1-x86_64.pkg.tar.zst"
+sha256 = "a72d3bad500752b03b154e4f93fe3d809a4081d72c571c4d67c7c911bd2f2f6f"
+signature = "iHUEABYIAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZMkgUAAKCRB2pe+QVESaXL97APwL52jcwCSn8YjpE4OxiU+qYvu5Kk4EmE5ynPhuNAvPnQD/Ym7uBtyg7W9TVIJTMZjbn8cG7laUZ8v4dJSZFKlpfAo="
+
+[[package]]
+name = "pacman-mirrorlist"
+version = "20230820-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/pacman-mirrorlist/pacman-mirrorlist-20230820-1-any.pkg.tar.zst"
+sha256 = "629077253f91ff076eb17f49339a014e889c4cf7fac27b900e75dc1fd285def3"
+signature = "iQIzBAABCgAdFiEEz6avFeXHQUn8HYwIbRZVwUzhwT4FAmTiIKQACgkQbRZVwUzhwT7MUw//crEda9o2IFSfTsRd6qzsSNaksB39fmKGPG/yJPVaFYgmRPMXG3ah30IOHD8QoltXyq+yDOHAaVRQsSsawDwOwiO0Dd01pz+fne6yfo5lf+hiW4y18NGOgb34G3SN2MZ4ecuJLzasy8owIV4VLOSRlvuHvz/2PtGCKfnmtZBjstFNZE1bSg3gE+QfOjUHo4t3CfpSwa9jVqgQ0XlXV5ji8kgvdPqSsvFfgss7nvw7sp1AZKvR2aXk0y1v3JNKs12ku4QyUp0WXYFXbBYwAx4Pt2ewpn7tL7/2H11qnfxb/pau7GT0/Zfw9Txe0K34gEVg9YaxSPEh0ac0rzkyHl0Jj9GUJUAw6der0fWIOl9OY2Z+tdQk+kaaKqHUdqh9nCLZIaUOydI+5vfENaTnqy4RNRQ9WO3QbDV1oc2CP42IFiMWZWoP4nO+16aAapsDDLjuKb/BOrO4KnTDfB3XV9LI+qvrklnsCx74pgtc1q6Wt5dBIc2SgouWZfvXMI0INqkMCxpxtS7Ue+Fgdf5BtUZX1upYjDOrsDhGIZHCjI/L96EwpL1Z8yNBze8q6bBZdAsFMDEs2bUwfb5ryiRH3L2pMqgbUmyh6OLcT1XKuI6xjeHs3kBACmcx9ZDtXdGMfKKr4kDvSLN5PwsbQdTIGcQsFgGcWumgQKuJvb4MX3K5ChU="
+
+[[package]]
+name = "rust"
+version = "1:1.72.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.72.0-1-x86_64.pkg.tar.zst"
+sha256 = "9033e678e283efc6a9d373483eae8d23d6e243f47c2ff14285c4734c9df39818"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZOeKDRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8de3gEA7a8jINYM9Wq4cpU2D+erLnFLf0ZQFqsRD4UZd2HQrLoBALlxnKl8yQtgf12LRuBjsyC/dqg7ZO69gUwrsMFlrnoE"
 
 [[package]]
 name = "rust-musl"
-version = "1:1.69.0-3"
+version = "1:1.72.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1%3A1.69.0-3-x86_64.pkg.tar.zst"
-sha256 = "5a4854cdac8312dbf72fb87795bcc36bfb34e9218944966e5ac2e62319bbcf22"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZExVKRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8cCMQD/W59RkOVPZDXlnmyY27jW61GC86hXOkSLOKa7XMQtpBoBALSugCkG1clSo/EQDbnuS+UY3268HNBvz6mF6i/hhEsB"
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.72.0-1-x86_64.pkg.tar.zst"
+sha256 = "7e12a0ee39b9aff7b29001707dbcc3b14bbd4a76465f33c2e2cc53f576d21de8"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZOeKDRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8fhkQEAlgC+zx9+6AghtuA+ou1OyV3+WNLAYTiDZPNwpMBj1XQA/ievy4teuWWRiQmL+Te82gD4TJthIA9QnkKvn+1TePYF"
+
+[[package]]
+name = "sqlite"
+version = "3.43.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.43.0-1-x86_64.pkg.tar.zst"
+sha256 = "d4a9813ab8deefb2b6ee57618f3b4fa8a8f7239abc962a719729cc14235da11f"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmTnhm4ACgkQlGV6sg8qCSteLggAkum0JqzoVJfIdBUr4zJJqt49sP/b3a8aP9VHOXQlOuvqK9K2sI87ZS526h+NtDz8q5AtM08qavprPKFBNmphPqzd8NbZNsCp3Yu99sOOQtrA1sR9HkLqG/bGyGuCZCt7+bjoBEWfePnvFnlIkIhPoqhF/otkhXGdsddWE9gZoLgFexd9opmWWLIV7xlkNPpZ2p9xOO6LhD0689LFJTEftdfsp9kb8PRqVW4w0erxg8wAn/FpzHx0WBfaMgJ51hLVB3VdDRmw1776sXXhGXWKn2LkkuXJ1POOxypOMbnrQxrmfEDYYtoTEGEz6ZCaNoChPavIu99fDZ2XX31kvbrv4g=="
+
+[[package]]
+name = "systemd"
+version = "254.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-254.1-1-x86_64.pkg.tar.zst"
+sha256 = "52b8f807841b7df7d865ea838969165e7f05b06869435fc37762652ca269adfc"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGj/VhAPwNuOhzKRPYlPvHFX6GlODMLHhQcQjBUxHjnwfxFaTJaAEA8pedTxMGVTbOpr9X48Qp0s7YdNwH8Lzl2s8OJhELMAg="
+
+[[package]]
+name = "systemd-libs"
+version = "254.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-254.1-1-x86_64.pkg.tar.zst"
+sha256 = "2691d25b17372d8c364f797762ffa20ff41032ed201752b2d9afb4f924f8b5b8"
+signature = "iHQEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGjzJgAPd+Unhwy7CFUfyBBIxa6gOt6WLBL4Q2o4AqGJJkR9BpAQCv9ZtQ09LhZf4ema/Ex8s9l4xYOYnZ3zRsnet993ChCA=="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "254.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-254.1-1-x86_64.pkg.tar.zst"
+sha256 = "a1b1d78b43fffae993d8cfd40976df2c83402083b9590d523839f535a73a9109"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGj4LqAQC/q5mr8lgdHxjwP8R6NR7gCZlGBvpGtamBW3O9dintRQEAom0Niy7wfyWlOlsl+V+lA4Myf4oPHYE4q81IGC/+CgI="
+
+[[package]]
+name = "tar"
+version = "1.35-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/t/tar/tar-1.35-1-x86_64.pkg.tar.zst"
+sha256 = "c4103c42ae8825ca9c679cb23e088e750c0df67aaa02e6e0164fc198f44c61ae"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMAT8wAKCRDluymEcK1OQT0pAP9/E2Wsq+dPo0gG/rPJGdNK/9OomXskc2I2ktEs5TbEnAEAwGV/vG0bpqh2+I7+x0UEbPcbKdVpkPT8UL7wK4k1QQM="
+
+[[package]]
+name = "util-linux"
+version = "2.39.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/u/util-linux/util-linux-2.39.2-1-x86_64.pkg.tar.zst"
+sha256 = "1cc8c68961d2768211dfb8462eed70484a83e4e0ef720f483f224aec4e005de9"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZN3uggAKCRBtQr3RFuAGj5fqAP49YRjF93QI52v6QtOXxG4CErwC5gFvRu5C4FiU1GQqaAEAsA2N1XIxs1mILcM6i5dodXGWi+09HGGuzAzbQ0motgs="
+
+[[package]]
+name = "util-linux-libs"
+version = "2.39.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.39.2-1-x86_64.pkg.tar.zst"
+sha256 = "96cafced0e65318cb17fff749a55c486df660f38407187aa2f50df179aa38fd1"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZN3uggAKCRBtQr3RFuAGj887AQDgmLTwNi5Up5byJOAVlRuCWyny58LS2M7Gh/m4XkP8GQD/TkynC7YZhezIkmPQqxPyB0Z0JUG21/rpn16fHdU8HQk="
+
+[[package]]
+name = "xz"
+version = "5.4.4-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/x/xz/xz-5.4.4-1-x86_64.pkg.tar.zst"
+sha256 = "cdda098368bcb508bbce77bb41ef5930ece769d440eac2350e8ae7f4607d81be"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZMq2IwAKCRBtQr3RFuAGj/PQAQCFBotlapDBNzZslbJs6ejiRwuiHnaCwa0cwQyiPh9TaAD+JEVZuixvbYCc2DNtxO3cNqvKBMz4lTFzxBGHuZ70wwA="
+
+[[package]]
+name = "zlib"
+version = "1:1.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/z/zlib/zlib-1:1.3-1-x86_64.pkg.tar.zst"
+sha256 = "8a9b1e5e354197828e74860b846a951cd981833d1b07ae182a539b0524b6ef3a"
+signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZOJANQAKCRATmwnaW/DTOLH2AP438CJVUrT2M0up+mcpoepk97VYMDdtPMIiS6lX4e7t7QEA5rJF9Yp5dS2qpnRLlTUdMVhSPAxrqGEq27U5ZzeUHA0="

--- a/src/remote_clock.rs
+++ b/src/remote_clock.rs
@@ -17,7 +17,7 @@ pub async fn determine(device: &Device) -> Result<(DateTime<Utc>, DateTime<Utc>,
 
 fn parse(s: &str) -> Result<DateTime<Utc>> {
     let dt = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %T %f")?;
-    Ok(DateTime::<Utc>::from_utc(dt, Utc))
+    Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The latest rust-musl package is currently broken, using this opportunity to test the CI correctly catches it.