### PR TITLE
Show hits on stalkerware-rules in TUI

### DIFF
--- a/src/scan.rs
+++ b/src/scan.rs
@@ -104,6 +104,15 @@ pub async fn run(
                         pkg.id, name
                     );
                     warn!("Suspicious {:?}: {}", SuspicionLevel::High, alert);
+                    report
+                        .app(
+                            pkg.id.clone(),
+                            Suspicion {
+                                level: SuspicionLevel::High,
+                                description: alert,
+                            },
+                        )
+                        .await?;
                 }
 
                 // fetch infos about package


### PR DESCRIPTION
Include it in the TUI results, if a rule identifies a known stalkerware.